### PR TITLE
Update photoswipe-ui-default.js

### DIFF
--- a/photog/static/photoswipe/photoswipe-ui-default.js
+++ b/photog/static/photoswipe/photoswipe-ui-default.js
@@ -445,11 +445,11 @@
             {
                 name: 'button--share',
                 option: 'shareEl',
-                onInit: function(el) {
-                    _shareButton = el;
-                },
                 onTap: function() {
-                    _toggleShareModal();
+                    var a = document.createElement('a');
+                    a.href = pswp.currItem.original;
+                    a.download = pswp.currItem.original;
+                    a.click();
                 }
             },
             {


### PR DESCRIPTION
Update behaviour of "share button". One could also add another button instead of changing this.

Download-icon-SVG needs to be added an it should be used in the CSS.